### PR TITLE
feat(dag): basics (put, get)

### DIFF
--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
     "eslint-plugin-react": "^6.9.0",
     "gulp": "^3.9.1",
     "hapi": "^16.1.0",
-    "interface-ipfs-core": "^0.23.5",
+    "interface-ipfs-core": "^0.23.6",
     "ipfsd-ctl": "^0.18.2",
     "pre-commit": "^1.2.2",
     "socket.io": "^1.7.2",

--- a/src/api/dag.js
+++ b/src/api/dag.js
@@ -1,0 +1,69 @@
+'use strict'
+
+const dagPB = require('ipld-dag-pb')
+const DAGNode = dagPB.DAGNode
+const DAGLink = dagPB.DAGLink
+const promisify = require('promisify-es6')
+const bs58 = require('bs58')
+const streamToValue = require('../stream-to-value')
+const cleanMultihash = require('../clean-multihash')
+const LRU = require('lru-cache')
+
+const lruOptions = {
+  max: 128
+}
+
+const Unixfs = require('ipfs-unixfs')
+const cache = LRU(lruOptions)
+
+module.exports = (send) => {
+  const api = {
+    get: promisify((cid, options, callback) => {
+      if (typeof options === 'function') {
+        callback = options
+        options = {}
+      }
+
+      options = options || {}
+
+      const node = cache.get(cid)
+
+      if (node) { return callback(null, node) }
+
+      send({
+        path: 'dag/get',
+        args: cid
+      }, (err, result) => {
+        if (err) {
+          return callback(err)
+        }
+
+        // TODO we need to get the raw bytes
+      })
+    }),
+
+    put: promisify((dagNode, multicodec, hashAlg, options, callback) => {
+      if (typeof options === 'function') {
+        callback = options
+        options = {}
+      }
+
+      options = options || {}
+
+      send({
+        path: 'dag/put',
+        qs: {
+          format: multicodec,
+          inputenc: enc
+        },
+        files: buf
+      }, (err, result) => {
+        if (err) { return callback(err) }
+
+        // TODO should get the CID back
+      })
+    })
+  }
+
+  return api
+}

--- a/src/load-commands.js
+++ b/src/load-commands.js
@@ -20,6 +20,7 @@ function requireCommands () {
     mount: require('./api/mount'),
     name: require('./api/name'),
     object: require('./api/object'),
+    dag: require('./api/dag'),
     pin: require('./api/pin'),
     ping: require('./api/ping'),
     refs: require('./api/refs'),
@@ -31,7 +32,7 @@ function requireCommands () {
 
   // TODO: crowding the 'files' namespace temporarily for interface-ipfs-core
   // compatibility, until 'files vs mfs' naming decision is resolved.
-  cmds.files = function (send) {
+  cmds.files = (send) => {
     const files = require('./api/files')(send)
     files.add = require('./api/add')(send)
     files.createAddStream = require('./api/create-add-stream.js')(send)
@@ -41,7 +42,7 @@ function requireCommands () {
     return files
   }
 
-  cmds.util = function (send) {
+  cmds.util = (send) => {
     const util = {
       addFromFs: require('./api/util/fs-add')(send),
       addFromStream: require('./api/add')(send),

--- a/test/interface/dag.spec.js
+++ b/test/interface/dag.spec.js
@@ -1,0 +1,20 @@
+/* eslint-env mocha */
+
+'use strict'
+
+const test = require('interface-ipfs-core')
+const FactoryClient = require('../ipfs-factory/client')
+
+let fc
+
+const common = {
+  setup: function (callback) {
+    fc = new FactoryClient()
+    callback(null, fc)
+  },
+  teardown: function (callback) {
+    fc.dismantle(callback)
+  }
+}
+
+test.dag(common)


### PR DESCRIPTION
Started implementing https://github.com/ipfs/interface-ipfs-core/pull/112 on js-ipfs-api, but there are somethings missing, from ipfs dag cli we have:

```
» ipfs dag put --help
USAGE
  ipfs dag put <object data> - Add a dag node to ipfs.

SYNOPSIS
  ipfs dag put [--format=<format> | -f] [--input-enc=<input-enc>] [--] <object data>

ARGUMENTS

  <object data> - The object to put

OPTIONS

  -f,        --format string - Format that the object will be added as. Default: cbor.
  --input-enc         string - Format that the input object will be. Default: json.

DESCRIPTION

  'ipfs dag put' accepts input from a file or stdin and parses it
  into an object of the specified format.
```

It would be great if we could use the multicodec names for the `format` flag, namely:

- dag-cbor
- dag-pb
- eth-block
- and so on

It will solve a lot of ambiguity. Can we get that @whyrusleeping ?

Another thing, it has no option to pick the hash algorithm to use.

Last note, the `--input-enc` defaults to json, but if we can use the multicodec of the type, we could send them serialized directly.

