### PR TITLE
Fix the `ping` results

### DIFF
--- a/src/api/ping.js
+++ b/src/api/ping.js
@@ -21,10 +21,14 @@ module.exports = (send) => {
 
         // go-ipfs http api currently returns 3 lines for a ping.
         // they're a little messed, so take the correct values from each lines.
+        const Success = res[1].Success
+        const Time = res[1].Time
+        const Text = res.length > 2 ? res[2].Text : res[1].Text
+
         const pingResult = {
-          Success: res[1].Success,
-          Time: res[1].Time,
-          Text: res[2].Text
+          Success: Success,
+          Time: Time,
+          Text: Text
         }
 
         callback(null, pingResult)


### PR DESCRIPTION
I've see cases where the `ping` response is in fact on 2 lines, the second one containing the Success (`false`), the Time and the Text. This happens for example if you try to ping your self.