### PR TITLE
fix: Support api endpoint with no port defined

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "detect-node": "^2.0.3",
     "flatmap": "0.0.3",
     "glob": "^7.1.2",
+    "ip-regex": "^3.0.0",
     "ipfs-block": "~0.7.1",
     "ipfs-unixfs": "~0.1.14",
     "ipld-dag-cbor": "~0.12.0",

--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,6 @@
 'use strict'
 
+const ipRegex = require('ip-regex')
 const multiaddr = require('multiaddr')
 const loadCommands = require('./utils/load-commands')
 const getConfig = require('./utils/default-config')
@@ -15,7 +16,19 @@ function IpfsAPI (hostOrMultiaddr, port, opts) {
   } catch (e) {
     if (typeof hostOrMultiaddr === 'string') {
       config.host = hostOrMultiaddr
-      config.port = port && typeof port !== 'object' ? port : config.port
+      const addrParts = hostOrMultiaddr.split(':')
+      if (addrParts.length === 1 && ipRegex.v4({ exact: true }).test(addrParts[0]) &&
+          (!port || typeof port === 'object')) {
+        // IPv4 Host with no port specified
+        config.port = undefined
+      } else if (addrParts.length === 2 && ipRegex.v4({ exact: true }).test(addrParts[0]) &&
+          (!port || typeof port === 'object')) {
+        // IPv4 Host with port specified
+        config.host = addrParts[0]
+        config.port = addrParts[1]
+      } else {
+        config.port = port
+      }
     }
   }
 

--- a/test/constructor.spec.js
+++ b/test/constructor.spec.js
@@ -50,6 +50,12 @@ describe('ipfs-api constructor tests', () => {
       clientWorks(ipfsAPI(apiAddr, { protocol: 'http' }), done)
     })
 
+    it('host:port', (done) => {
+      const splitted = apiAddr.split('/')
+
+      clientWorks(ipfsAPI(`${splitted[2]}:${splitted[4]}`), done)
+    })
+
     it('host, port', (done) => {
       const splitted = apiAddr.split('/')
 


### PR DESCRIPTION
According to my previous comments on the Issue, I submitted this PR.

The multiaddr error fallback was modified, removing the default port, in order to allow hostnames with no port specified.

Closes #581 