### PR TITLE
fix: config get

### DIFF
--- a/package.json
+++ b/package.json
@@ -80,7 +80,7 @@
     "eslint-plugin-react": "^7.10.0",
     "go-ipfs-dep": "~0.4.17",
     "gulp": "^3.9.1",
-    "interface-ipfs-core": "~0.73.0",
+    "interface-ipfs-core": "~0.75.0",
     "ipfsd-ctl": "~0.39.0",
     "pull-stream": "^3.6.8",
     "socket.io": "^2.1.1",

--- a/src/config/get.js
+++ b/src/config/get.js
@@ -2,6 +2,14 @@
 
 const promisify = require('promisify-es6')
 
+const toObject = function (res, callback) {
+  if (Buffer.isBuffer(res)) {
+    callback(null, JSON.parse(res.toString()))
+  } else {
+    callback(null, res)
+  }
+}
+
 module.exports = (send) => {
   return promisify((key, callback) => {
     if (typeof key === 'function') {
@@ -10,18 +18,18 @@ module.exports = (send) => {
     }
 
     if (!key) {
-      send({
+      send.andTransform({
         path: 'config/show',
         buffer: true
-      }, callback)
+      }, toObject, callback)
       return
     }
 
-    send({
+    send.andTransform({
       path: 'config',
       args: key,
       buffer: true
-    }, (err, response) => {
+    }, toObject, (err, response) => {
       if (err) {
         return callback(err)
       }

--- a/test/interface.spec.js
+++ b/test/interface.spec.js
@@ -174,7 +174,9 @@ describe('interface-ipfs-core tests', () => {
       {
         name: 'should stop the node',
         reason: 'FIXME go-ipfs returns an error https://github.com/ipfs/go-ipfs/issues/4078'
-      }
+      },
+      // resolve
+      'resolve'
     ]
   })
 


### PR DESCRIPTION
Fixes config.get by always returning an object and never a buffer. It can be a possible breaking change for those using js-ipfs-api with go-ipfs, but not with js-ipfs.

Fixes https://github.com/ipfs/js-ipfs-api/issues/822.